### PR TITLE
Remove unnecessary map

### DIFF
--- a/scrape.js
+++ b/scrape.js
@@ -1,4 +1,4 @@
-Array.from(document.querySelectorAll('.itemlist .athing')).map(el => {
+Array.from(document.querySelectorAll('.itemlist .athing'), el => {
   const title = el.querySelector('a.titlelink').innerText;
   const points = parseInt(el.nextSibling.querySelector('.score').innerText);
   const url = el.querySelector('a.titlelink').href;


### PR DESCRIPTION
A tiny improvement.

From [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from#description):

> `Array.from()` has an optional parameter `mapFn`, which allows you to execute a `map()` function on each element of the array being created.